### PR TITLE
Added CHANGELOG.md to Ignition 8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# eWON Ignition 8 Connector Changelog
+
+## v1.1.5
+
+### Major Changes
+
+* None
+
+### Minor Changes
+
+* Included CHANGELOG.md in release
+* Removed logging of "Updating Live Values"
+* Updated license for module
+
+## v1.1.4
+
+### Major Changes
+
+* None
+
+### Minor Changes
+
+* Tags can now be removed and created again without restarting the module
+* Logging of "Updating Live Values" level changed to "Trace"
+
+## v1.1.3
+### Major Changes
+* Realtime reads from the Flexy
+* Ignition to Flexy writes
+* Support for tag deletion
+* Configuration parameters are now URL friendly
+* Support for String tag values
+
+### Minor Changes
+* Support for periods in tag names

--- a/tools/MakeRelease.py
+++ b/tools/MakeRelease.py
@@ -16,12 +16,14 @@ RELEASE_PATH = "../releases/"
 
 #File names for release files
 README_FILENAME     = "README.md"
+CHANGELOG_FILENAME     = "CHANGELOG.md"
 MODL_FILENAME       = PROJECT_NAME + "-Ignition-Module-unsigned.modl"
 BUILD_XML_FILENAME  = "pom.xml"
 
 
 #Paths for release files
 README_PATH     = "../"
+CHANGELOG_PATH  = "../"
 MODL_PATH       = "../eWonConnector-build/target"
 BUILD_XML_PATH  = "../eWonConnector-build"
 
@@ -60,6 +62,7 @@ def CreateRelease():
 
    #Add all "release" files to the zip
    zf.write(os.path.abspath(os.path.join(README_PATH,README_FILENAME)), README_FILENAME)
+   zf.write(os.path.abspath(os.path.join(CHANGELOG_PATH,CHANGELOG_FILENAME)), CHANGELOG_FILENAME)
    zf.write(os.path.abspath(os.path.join(MODL_PATH,MODL_FILENAME)), MODL_FILENAME)
 
    #Close the release zip folder


### PR DESCRIPTION
To allow customers to keep track of new features, bugfixes, etc a changelog has been added to the release folder.  This allows for releases to be pulled from GitHub if we please without loosing customer facing changelog type documentation. 