### PR TITLE
Boolean fix

### DIFF
--- a/eWonConnector-gateway/src/main/java/org/imdc/ewon/SyncManager.java
+++ b/eWonConnector-gateway/src/main/java/org/imdc/ewon/SyncManager.java
@@ -480,8 +480,12 @@ public class SyncManager {
                                     String tagName = replaceUnderscore
                                             ? unSanitizeName(tagPath.getItemName())
                                             : tagPath.getItemName();
+                                    String writeValue = o.toString();
+                                    if (o instanceof Boolean) {
+                                        writeValue = (Boolean) o ? "1" : "0";
+                                    }
                                     comm.writeTag(tagPath.getParentPath().getItemName(), tagName,
-                                            o.toString());
+                                            writeValue);
                                     provider.updateValue(p, o, QualityCode.Good);
                                 } catch (Exception e) {
                                     logger.error("Writing tag to eWON via Talk2M API Failed");


### PR DESCRIPTION
the m2web api takes "1" or "0" for the value of boolean tags.  In Ignition the string value for Boolean tags is "true" or "false" so we must convert to use the m2web values.
 